### PR TITLE
Change URI to the more specific URL

### DIFF
--- a/locale/en-US.properties
+++ b/locale/en-US.properties
@@ -1,4 +1,4 @@
-context_menu_item_label=Open this URI in Wayback Machine
+context_menu_item_label=Open this URL in Wayback Machine
 button_label=Open current page in Wayback Machine
 wayback_machine_url_title=Wayback Machine URL
 wayback_machine_url_description=In case Wayback Machine will ever change its base URL, you can set it here yourself without waiting for this addon to update.


### PR DESCRIPTION
All URIs used for web addresses are URLs and are more commonly referred to as such.
It feels more natural to me at least.
